### PR TITLE
Allow navigation via reactions

### DIFF
--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -93,6 +93,10 @@ class Dwitter:
                                         await originalMessage.edit_message(embed = e)
                         else:
                                 replyStatic = True
+		try:
+			await originalMessage.clear_reactions()
+		except Forbidden:
+			return None
 
 	async def embeddweet(self, dweet):
 		e = discord.Embed()

--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -80,7 +80,7 @@ class Dwitter:
                         except asyncio.TimeoutError:
                                 opReaction = None
                         if not opReaction is None:
-                                remove_reaction(originalMessage, opReaction.reaction.emoji, message.author)
+                                await originalMessage.remove_reaction(opReaction.reaction.emoji, message.author)
                                 if opReaction.reaction.emoji == leftArrow:
                                         id+=1
                                 elif opReaction.reaction.emoji == rightArrow:

--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -90,7 +90,7 @@ class Dwitter:
                                 dweet = await self.bot.request('get', self.url + 'api/dweets/' + id)
                                 if not (dweet is None or 'link' not in dweet):
                                         e = await self.embeddweet(dweet)
-                                        await edit_message(originalMessage, embed = e)
+                                        await originalMessage.edit_message(embed = e)
                         else:
                                 replyStatic = True
 

--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -54,9 +54,9 @@ class Dwitter:
                 terminator = "\u23F9"
 		e = await self.embeddweet(dweet)
 		originalMessage = await message.channel.send(embed=e)
-		await add_reaction(originalMessage, leftArrow)
-		await add_reaction(originalMessage, terminator)
-		await add_reaction(originalMessage, rightArrow)
+		await originalMessage.add_reaction(leftArrow)
+		await originalMessage.add_reaction(terminator)
+		await originalMessage.add_reaction(rightArrow)
 
 		# don't count my own links because I only use it for testing
 		if await self.bot.is_owner(message.author):

--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -71,7 +71,7 @@ class Dwitter:
 		dwit.save()
 
 		def checkReaction(opReaction, user):
-                        return (opReaction.reaction.emoji in [leftArrow, rightArrow, terminator]) and (user=message.author) and (opReaction.message=originalMessage)
+                        return (opReaction.reaction.emoji in [leftArrow, rightArrow, terminator]) and (user==message.author) and (opReaction.message==originalMessage)
 
                 replyStatic = False
                 while not replyStatic:

--- a/cogs/guilds/dwitter.py
+++ b/cogs/guilds/dwitter.py
@@ -71,7 +71,7 @@ class Dwitter:
 		dwit.save()
 
 		def checkReaction(opReaction, user):
-                        return (opReaction.reaction.emoji in [leftArrow, rightArrow, terminator]) and (user==message.author) and (opReaction.message==originalMessage)
+                        return (str(opReaction.reaction.emoji) in [leftArrow, rightArrow, terminator]) and (user==message.author) and (opReaction.message==originalMessage)
 
                 replyStatic = False
                 while not replyStatic:
@@ -81,11 +81,11 @@ class Dwitter:
                                 opReaction = None
                         if not opReaction is None:
                                 await originalMessage.remove_reaction(opReaction.reaction.emoji, message.author)
-                                if opReaction.reaction.emoji == leftArrow:
+                                if str(opReaction.reaction.emoji) == leftArrow:
                                         id+=1
-                                elif opReaction.reaction.emoji == rightArrow:
+                                elif str(opReaction.reaction.emoji) == rightArrow:
                                         id-=1
-                                elif opReaction.reaction.emoji == terminator:
+                                elif str(opReaction.reaction.emoji) == terminator:
                                         replyStatic = True
                                 dweet = await self.bot.request('get', self.url + 'api/dweets/' + id)
                                 if not (dweet is None or 'link' not in dweet):


### PR DESCRIPTION
Causes the bot to automatically react to any embed post it makes with a left arrow, a stop button, and a right arrow. If the user who requested the embed reacts with one of these themselves, the dweet will change to the one directly before it or after it, for the right and left arrows respectively, or will be permanently set to a specific dweet if the terminator is used.