### PR TITLE
Add trivia categories.

### DIFF
--- a/cogs/games.py
+++ b/cogs/games.py
@@ -52,8 +52,8 @@ DIFFICULTY_COLORS = {
 }
 
 API_BASE = 'https://opentdb.com/'
-API_CATEGORY_LIST_URL = f'{API_BASE}api_category.php'
-API_URL = f'{API_BASE}api.php'
+API_CATEGORY_LIST_URL = '{}api_category.php'.format(API_BASE)
+API_URL = '{}api.php'.format(API_BASE)
 QUESTION_TIMEOUT = 20.0
 
 MULTIPLE_MAP = (
@@ -96,7 +96,11 @@ class CategoryConverter(commands.Converter):
 		try:
 			return TRIVIA_CATEGORIES[category_name]
 		except KeyError:
-			raise commands.CommandError('\'{}\' is not a valid trivia category, see the categories command.'.format(argument.lower()))
+			try:
+				if Difficulty[argument.upper()]:
+					return argument
+			except:
+				raise commands.CommandError('\'{}\' is not a valid trivia category, see the categories command.'.format(argument.lower()))
 
 class DifficultyConverter(commands.Converter):
 	async def convert(self, ctx, argument):
@@ -157,7 +161,10 @@ class Games(AceMixin, commands.Cog):
 	async def trivia(self, ctx, category: CategoryConverter = None, *, difficulty: DifficultyConverter = None):
 		'''Trivia time! Optionally specify a difficulty as argument. Valid difficulties are `easy`, `medium` and `hard`.'''
 
-		diff = difficulty
+		if (category is not None) and (type(category) != int):
+			diff = await DifficultyConverter.convert(ctx, category, category)
+		else:
+			diff = difficulty
 
 		if diff is None:
 			diff = choice(list(Difficulty))
@@ -169,7 +176,7 @@ class Games(AceMixin, commands.Cog):
 			#type='boolean'
 		)
 
-		if category is not None:
+		if type(category) == int:
 			params['category'] = category
 
 		try:
@@ -311,7 +318,7 @@ class Games(AceMixin, commands.Cog):
 
 		for category_name in TRIVIA_CATEGORIES:
 			if category_name.find(':') == -1: # Only show the trimmed categories, since the other ones are redundent and both work
-				entries.append(f'`{category_name}`')
+				entries.append('`{}`'.format(category_name))
 
 		e = discord.Embed(
 			description='\n'.join(entries),

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -137,14 +137,17 @@ class Games(AceMixin, commands.Cog):
 		categories_id_map = {}
 
 		for category in res['trivia_categories']:
-			name = category['name'] # Name is sometimes something like `GeneralCategory: SpecificCategory`, like `Entertainment: Books`, so we just trim that out if it's there
+			name = category['name'].lower() # Name is sometimes something like `GeneralCategory: SpecificCategory`, like `Entertainment: Books`, so we just trim that out if it's there
 			colon_pos = name.find(':')
-			trimmed_name = name[0 if colon_pos == -1 else colon_pos + 2:].lower()
+			trimmed_name = name[0 if colon_pos == -1 else colon_pos + 2:]
 
 			if trimmed_name != name:
 				categories_id_map[name] = category['id'] # However, if it is a XXX: YYY category, we do include both names
 
 			categories_id_map[trimmed_name] = category['id'] # Map the name to ID, so a user can enter a name instead of an ID
+
+		categories_id_map['anime'] = categories_id_map['japanese anime & manga']
+		categories_id_map['science'] = categories_id_map['science & nature']
 
 		TRIVIA_CATEGORIES = categories_id_map
 
@@ -301,6 +304,20 @@ class Games(AceMixin, commands.Cog):
 			'INSERT INTO trivia_stats (guild_id, user_id, timestamp, question_hash, result) VALUES ($1, $2, $3, $4, $5)',
 			ctx.guild.id, ctx.author.id, answered_at, question_hash, result
 		)
+
+	@trivia.command()
+	async def categories(self, ctx):
+		entries = list()
+
+		for category_name in TRIVIA_CATEGORIES:
+			if category_name.find(':') == -1: # Only show the trimmed categories, since the other ones are redundent and both work
+				entries.append(f'`{category_name}`')
+
+		e = discord.Embed(
+			description='\n'.join(entries),
+		)
+
+		await ctx.send(embed=e)
 
 	@trivia.command()
 	@commands.bot_has_permissions(embed_links=True)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -159,7 +159,7 @@ class Games(AceMixin, commands.Cog):
 	@commands.bot_has_permissions(embed_links=True, add_reactions=True)
 	@commands.cooldown(rate=1, per=300.0, type=commands.BucketType.member)
 	async def trivia(self, ctx, category: CategoryConverter = None, *, difficulty: DifficultyConverter = None):
-		'''Trivia time! Optionally specify a difficulty as argument. Valid difficulties are `easy`, `medium` and `hard`.'''
+		'''Trivia time! Optionally specify a difficulty or category and difficulty as arguments. Valid difficulties are `easy`, `medium` and `hard`. Valid categories can be listed with `trivia categories`.'''
 
 		if (category is not None) and (type(category) != int):
 			# If the category converter was called, and didn't return an int, then it actually return the difficulty (which can optionally be the first param)
@@ -316,6 +316,7 @@ class Games(AceMixin, commands.Cog):
 
 	@trivia.command()
 	async def categories(self, ctx):
+		'''Get a list of valid categories for the trivia command.'''
 		# Just dump the list of valid categories into an embed and send it
 		description = ''
 

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -106,7 +106,9 @@ class CategoryConverter(commands.Converter):
 
 class DifficultyConverter(commands.Converter):
 	async def convert(self, ctx, argument):
-		name = argument.upper()
+		cleaner = commands.clean_content(escape_markdown=True)
+
+		name = await cleaner.convert(ctx, argument.upper())
 
 		try:
 			return Difficulty[name]
@@ -116,7 +118,7 @@ class DifficultyConverter(commands.Converter):
 		try:
 			return Difficulty(int(name))
 		except ValueError:
-			raise commands.CommandError('\'{}\' is not a valid difficulty.'.format(discord.escape_markdown(argument.lower())))
+			raise commands.CommandError('\'{}\' is not a valid difficulty.'.format(name))
 
 
 class Games(AceMixin, commands.Cog):


### PR DESCRIPTION
Since the trivia API supports getting questions for a specific category, I've changed the first parameter of the `trivia` command to a category option, which is handled in the converter `CategoryConverter` where it is checked if the parameter is in the global dict `TRIVIA_CATEGORIES`, which maps a (string) category to an (int) trivia API category ID.

`TRIVIA_CATEGORIES` is built in the method `Games.get_trivia_categories`, which is called by `Games.__init__()`, and makes a request to the trivia API's category list endpoint and then builds the map of names/IDs out of the result, and also creates some extra entries in the map for categories which have much more common names than the API uses.

`CategoryConverter` also checks if the parameter is a difficulty level, which allows for the trivia command to be used like originally, with just a single param being the difficulty. In this version, the trivia difficulty is always the last param, so it's the first without a category, and the second with a category. 

The trivia sub-command `trivia categories` simply enumerates the `TRIVIA_CATEGORIES` dict, and prints out all categories in a simple embed. 

The only other change I've made is escaping any markdown in any trivia converter classes, which stops user-provided markdown from showing up in the error messages.