### PR TITLE
Add 'rlx' command.

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -220,7 +220,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 
 		return results
 
-	async def cloudahk_call(self, ctx, code, lang = 'ahk'):
+	async def cloudahk_call(self, ctx, code, lang='ahk'):
 		'''Call to CloudAHK to run %code% written in %lang%. Replies to invoking user with stdout/runtime of code. '''
 
 		token = '{0}:{1}'.format(CLOUDAHK_USER, CLOUDAHK_PASS)


### PR DESCRIPTION
Adds a command to run Relax code through CloudAHK.
Requires `CLOUDAHK_URL` to not have a trailing `/` (or trailing `/ahk`) in config.py.