### PR TITLE
Add wta for help channel quoting

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -18,7 +18,6 @@ from utils.html2markdown import HTML2Markdown
 from utils.pager import Pager
 from utils.string import po
 from utils.time import pretty_timedelta
-from ids import OPEN_CATEGORY_ID, GET_HELP_CHANNEL_ID
 
 log = logging.getLogger(__name__)
 
@@ -429,18 +428,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 		'''Compile and run Relax code through CloudAHK. Example: `rlx define i32 Main() {return 20}`'''
 
 		await self.cloudahk_call(ctx, code, 'rlx')
-	
-	@commands.command()
-	async def wta(self,ctx):
-		open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
-		channels = list(open_category.text_channels)
-		channel_mentions = []
-		for i, c in enumerate(channels):
-			if c.id == GET_HELP_CHANNEL_ID:
-				continue
-		channel_mentions.append(c.mention)
-		await ctx.send("Please ask in a channel under **{}** category. Use either {} or {}.".format(open_category.name,*channel_mentions))
-	
+
 
 def setup(bot):
 	bot.add_cog(AutoHotkey(bot))

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -18,6 +18,7 @@ from utils.html2markdown import HTML2Markdown
 from utils.pager import Pager
 from utils.string import po
 from utils.time import pretty_timedelta
+from ids import OPEN_CATEGORY_ID, GET_HELP_CHANNEL_ID
 
 log = logging.getLogger(__name__)
 
@@ -428,7 +429,18 @@ class AutoHotkey(AceMixin, commands.Cog):
 		'''Compile and run Relax code through CloudAHK. Example: `rlx define i32 Main() {return 20}`'''
 
 		await self.cloudahk_call(ctx, code, 'rlx')
-
+	
+	@commands.command()
+	async def wta(self,ctx):
+		open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
+		channels = list(open_category.text_channels)
+		channel_mentions = []
+		for i, c in enumerate(channels):
+			if c.id == GET_HELP_CHANNEL_ID:
+				continue
+		channel_mentions.append(c.mention)
+		await ctx.send("Please ask in a channel under **{}** category. Use either {} or {}.".format(open_category.name,*channel_mentions))
+	
 
 def setup(bot):
 	bot.add_cog(AutoHotkey(bot))

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -495,22 +495,23 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 	def is_claimed(self, channel_id):
 		return channel_id in self.claimed_channel.values()
 
-	@commands.command(hidden=True)
+   	@commands.command(hidden=True, aliases=['ais'])
     	async def wta(self,ctx):
-		'''Responds with the currently open for claiming channels.'''
-        	open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
-        	channels = list(open_category.text_channels)
-        	channel_mentions = []
-        	for c in channels:
-        	    	if c.id == GET_HELP_CHAN_ID:
-                		continue
-            	channel_mentions.append(c.mention)
-        	wta_format = ""
-        	if len(channel_mentions) == 0:
-            		wta_format = "No help channels are available for questions at this time. Please wait to ask a question, or ask staff for guidance."
-        	else:
-            		wta_format = "Please ask in a channel under the **{}** category. Use " + (("{}, " *  (len(channel_mentions)-1) + "or ") if len(channel_mentions)-1 > 0 else "") + "{}."
-        	await ctx.send(wta_format.format(open_category.name,*channel_mentions))
+        	'''Responds with the currently open for claiming channels.'''
+        	async with self.channel_claim_lock:
+		    	open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
+		    	if open_category is None: 
+				await ctx.send("Something went wrong.")
+				return
+		    	open_help_channels = [channel for channel in open_category.text_channels if channel.id != GET_HELP_CHAN_ID]
+		    	if not open_help_channels:
+				await ctx.send("No help channels are available for questions at this time. Please wait to ask a question, or ask staff for guidance.")
+				return
+		    	open_help_channel_mentions = [c.mention for c in open_help_channels]
+		    	if len(open_help_channel_mentions) > 1:
+				open_help_channel_mentions[-1] = 'or ' + open_help_channel_mentions[-1]
+		    	wta_format = "Please ask in a channel under the **{}** category. Use {}."
+		    	await ctx.send(wta_format.format(open_category.name,', '.join(open_help_channel_mentions)))
 
 
 def setup(bot):

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -495,6 +495,23 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 	def is_claimed(self, channel_id):
 		return channel_id in self.claimed_channel.values()
 
+	@commands.command(hidden=True)
+    	async def wta(self,ctx):
+		'''Responds with the currently open for claiming channels.'''
+        	open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
+        	channels = list(open_category.text_channels)
+        	channel_mentions = []
+        	for c in channels:
+        	    	if c.id == GET_HELP_CHAN_ID:
+                		continue
+            	channel_mentions.append(c.mention)
+        	wta_format = ""
+        	if len(channel_mentions) == 0:
+            		wta_format = "No help channels are available for questions at this time. Please wait to ask a question, or ask staff for guidance."
+        	else:
+            		wta_format = "Please ask in a channel under the **{}** category. Use " + (("{}, " *  (len(channel_mentions)-1) + "or ") if len(channel_mentions)-1 > 0 else "") + "{}."
+        	await ctx.send(wta_format.format(open_category.name,*channel_mentions))
+
 
 def setup(bot):
 	bot.add_cog(AutoHotkeyHelpSystem(bot))


### PR DESCRIPTION
Added a wta [where to ask] command to send which channels are currently open and ready for claiming.
Must have the how-to-get-help channel added into the ids.py file as GET_HELP_CHANNEL_ID