### PR TITLE
Add wta for open help channel quoting

### DIFF
--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -18,7 +18,7 @@ from tensorflow import keras
 log.info('Finished importing keras.')
 
 from cogs.mixins import AceMixin
-from ids import ACTIVE_CATEGORY_ID, ACTIVE_INFO_CHAN_ID, AHK_GUILD_ID, CLOSED_CATEGORY_ID, GET_HELP_CHAN_ID, IGNORE_ACTIVE_CHAN_IDS, OPEN_CATEGORY_ID, RULES_CHAN_ID
+from ids import ACTIVE_CATEGORY_ID, ACTIVE_INFO_CHAN_ID, AHK_GUILD_ID, CLOSED_CATEGORY_ID, GET_HELP_CHAN_ID, IGNORE_ACTIVE_CHAN_IDS, OPEN_CATEGORY_ID, RULES_CHAN_ID, GET_HELP_CHANNEL_ID
 from utils.context import is_mod
 from utils.string import po
 from utils.time import pretty_timedelta
@@ -494,6 +494,23 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 
 	def is_claimed(self, channel_id):
 		return channel_id in self.claimed_channel.values()
+
+	@commands.command(hidden=True)
+    	async def wta(self,ctx):
+		'''Responds with the currently open for claiming channels.'''
+        	open_category = self.bot.get_channel(OPEN_CATEGORY_ID)
+        	channels = list(open_category.text_channels)
+        	channel_mentions = []
+        	for c in channels:
+        	    if c.id == GET_HELP_CHANNEL_ID:
+                	continue
+            	channel_mentions.append(c.mention)
+        	wta_format = ""
+        	if len(channel_mentions) == 0:
+            		wta_format = "No help channels are available for questions at this time. Please wait to ask a question, or ask staff for guidance."
+        	else:
+            		wta_format = "Please ask in a channel under the **{}** category. Use " + (("{}, " *  (len(channel_mentions)-1) + "or ") if len(channel_mentions)-1 > 0 else "") + "{}."
+        	await ctx.send(wta_format.format(open_category.name,*channel_mentions))
 
 
 def setup(bot):


### PR DESCRIPTION
Added a wta [where to ask] command to send which channels are currently open and ready for claiming.
Must have the how-to-get-help channel added into the ids.py file as GET_HELP_CHANNEL_ID