### PR TITLE
Add longer length support to .ahk

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -302,9 +302,10 @@ class AutoHotkey(AceMixin, commands.Cog):
 		encoded_stdout = stdout.encode('utf-8')
 		stdout_length = len(stdout)
 
-		if stdout_length < (1800 - stdout.count('```')*4/3) and stdout.count('\n') < 20:
+		if stdout_length < (1800) and stdout.count('\n') < 20:
 			#upload as plaintext
-			stdout = stdout.replace('```', '`\u200b``')
+			while '```' in stdout:
+				stdout = stdout.replace('```', '`\u200b``')
 			valid_response = '` No Output.\n`' if stdout == '' else '\n```autoit\n{0}\n```'.format(stdout)
 		
 

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -297,20 +297,21 @@ class AutoHotkey(AceMixin, commands.Cog):
 
 		stdout = stdout.replace('`', '`\u200b')
 		file = None
-		if len(stdout) < 1800 and stdout.count('\n') < 12 and stdout.count('\r') < 12:
+		encoded_out = stdout.encode('utf-8')
+		if len(stdout) < 1800 and stdout.count('\n') < 20 and stdout.count('\r') < 20:
 			#upload as plaintext
 			valid_response = 'No output.\n' if stdout == '' else '\n```autoit\n{0}\n```'.format(stdout)
-		elif len(stdout) < 100000:
+		elif len(encoded_out) < 100000 and AHK_GUILD_ID == ctx.guild.id:
 			#upload to ahkscript.org
 			data = {'name': 'Ace Bot (Clone)', 'code': stdout}
 			async with ctx.http.post('https://p.ahkscript.org/',data=data) as resp:
 				if resp.status != 200:
 					raise commands.CommandError('Pastebin failed.')
 				valid_response = ' No output.\n' if stdout == '' else f' Results too large. Pasted. {resp.url}\n'
-		elif len(stdout) < (1000*1000*4000): # should be 4mb
+		elif len(encoded_out) < (1000*1000*4000): # should be 4mb
 			fp = io.BytesIO(stdout.encode('utf-8'))
 			file = discord.File(fp, 'results.txt')
-			valid_response = ' No output.\n' if stdout == '' else ' Results too large for pastebin. See attached file.\n'
+			valid_response = ' No output.\n' if stdout == '' else ' Results too large. See attached file.\n'
 		else:
 			raise commands.CommandError('Output greater than 4mb.')
 

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -296,14 +296,15 @@ class AutoHotkey(AceMixin, commands.Cog):
 		stdout, time = result['stdout'].strip(), result['time']
 
 
-		stdout = stdout.replace('`', '`\u200b')
+
 		stdout = stdout.replace('\r', '')
 		file = None
 		encoded_stdout = stdout.encode('utf-8')
 		stdout_length = len(stdout)
 
-		if stdout_length < 1800 and stdout.count('\n') < 20:
+		if stdout_length < (1800 - stdout.count('```')*4/3) and stdout.count('\n') < 20:
 			#upload as plaintext
+			stdout = stdout.replace('```', '`\u200b``')
 			valid_response = '` No Output.\n`' if stdout == '' else '\n```autoit\n{0}\n```'.format(stdout)
 		
 

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -1,19 +1,18 @@
 import html
+import io
 import logging
 import re
-import io
 from base64 import b64encode
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 
 import discord
 from bs4 import BeautifulSoup
-from discord.ext import commands, tasks
-from fuzzywuzzy import fuzz, process
-
-from ids import *
 from cogs.mixins import AceMixin
 from config import CLOUDAHK_PASS, CLOUDAHK_URL, CLOUDAHK_USER
+from discord.ext import commands, tasks
+from fuzzywuzzy import fuzz, process
+from ids import *
 from utils.docs_parser import parse_docs
 from utils.html2markdown import HTML2Markdown
 from utils.pager import Pager

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -287,7 +287,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 		code = code.strip('`').strip()
 
 		# call cloudahk with 20 in timeout
-		async with self.bot.aiohttp.post('{}/{}'.format(CLOUDAHK_URL, lang), data=code, headers=headers, timeout=20) as resp:
+		async with self.bot.aiohttp.post('{}/{}/run'.format(CLOUDAHK_URL, lang), data=code, headers=headers, timeout=20) as resp:
 			if resp.status == 200:
 				result = await resp.json()
 			else:
@@ -302,16 +302,9 @@ class AutoHotkey(AceMixin, commands.Cog):
 		if len(stdout) < 1800 and stdout.count('\n') < 20 and stdout.count('\r') < 20:
 			#upload as plaintext
 			valid_response = '` No Output.\n`' if stdout == '' else '\n```autoit\n{0}\n```'.format(stdout)
-			
-		elif len(encoded_stdout) < 100000 and AHK_GUILD_ID == ctx.guild.id: #limit to 100kb
-			#upload to p.ahkscript.org
-			data = {'name': 'Ace Bot', 'code': encoded_stdout}
-			async with ctx.http.post('https://p.ahkscript.org/', data=data) as resp:
-				if resp.status != 200:
-					raise commands.CommandError('Pastebin failed.')
-				valid_response = f' Results too large. Pasted. {resp.url}\n'	
-				
-		elif len(encoded_stdout) < (8000000000): # limited to 8mb
+		
+
+		elif len(stdout) < (8000000000): # limited to 8mb
 			fp = io.BytesIO(encoded_stdout)
 			file = discord.File(fp, 'results.txt')
 			valid_response = ' Results too large. See attached file.\n'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py==1.5.1
+discord.py==1.6.0
 asyncpg==0.20.1
 aiohttp==3.6.2
 fuzzywuzzy==0.18.0


### PR DESCRIPTION
If responses are too long, upload to p.ahkscript,org.
If its longer than that, upload as a file.
Also added support to run code from p.ahkscript.org