### PR TITLE
Update cloudahk endpoint

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -286,7 +286,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 		code = code.strip('`').strip()
 
 		# call cloudahk with 20 in timeout
-		async with self.bot.aiohttp.post('{}/{}'.format(CLOUDAHK_URL, lang), data=code, headers=headers, timeout=16) as resp:
+		async with self.bot.aiohttp.post('{}/{}/run'.format(CLOUDAHK_URL, lang), data=code, headers=headers, timeout=16) as resp:
 			if resp.status == 200:
 				result = await resp.json()
 			else:


### PR DESCRIPTION
Cloudahk has recently been updated, and has a new endpoint to run code on. The current endpoint is deprecated and should be changed in the config.py file.
The new endpoint should be requested from @G33kDude.