### PR TITLE
Update source command to always link to Github

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -258,8 +258,15 @@ class Meta(AceMixin, commands.Cog):
 		"""Get a github link to the source code of a command."""
 
 		if source_item is None:
-			await ctx.send(GITHUB_LINK)
-			return
+			# check for image permissions and if we don't have them then just send the link
+			if not ctx.channel.permissions_for(ctx.me) >= discord.Permissions(embed_links=True):
+				await ctx.send(GITHUB_LINK)
+			else:
+				# send an embed
+				embed = discord.Embed(title='Bot Source',description=f'[Open in Github]({GITHUB_LINK} "Github Link")')
+				embed.set_footer(icon_url='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png')
+				await ctx.send(embed=embed)
+				return
 
 		# send a typing event 
 		# normally would be an async with,
@@ -284,8 +291,8 @@ class Meta(AceMixin, commands.Cog):
 
 		lines, first_line_no = inspect.getsourcelines(callback)
 
-		lines_extension = f"#L{first_line_no}-L{first_line_no+len(lines)-1}"
-		link = f"{GITHUB_LINK}/blob/{GITHUB_BRANCH}/{source_file}{lines_extension}"
+		link = f"{GITHUB_LINK}/blob/{GITHUB_BRANCH}/{source_file}" \
+			f"#L{first_line_no}-L{first_line_no+len(lines)-1}"
 
 		# check for image permissions and if we don't have them then just send the link
 		if not ctx.channel.permissions_for(ctx.me) >= discord.Permissions(embed_links=True):
@@ -293,7 +300,7 @@ class Meta(AceMixin, commands.Cog):
 			return
 
 		# make a fancy embed!
-		embed = discord.Embed(title=cmd.qualified_name,
+		embed = discord.Embed(title=f'Command: {cmd.qualified_name}',
 		                      description=f'[Open in Github]({link} "Github Repository Link")',)
 		embed.set_footer(
 			text=f"/{source_file}", icon_url='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png')

--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -288,28 +288,16 @@ class Meta(AceMixin, commands.Cog):
 		link = f"{GITHUB_LINK}/blob/{GITHUB_BRANCH}/{source_file}{lines_extension}"
 
 		# check for image permissions and if we don't have them then just send the link
-		if not ctx.channel.permissions_for(ctx.me) >= discord.Permissions(
-			embed_links=True, attach_files=True
-		):
+		if not ctx.channel.permissions_for(ctx.me) >= discord.Permissions(embed_links=True):
 			await ctx.send(link)
 			return
 
 		# make a fancy embed!
-		e = discord.Embed()
-		e.description = f"{cmd.short_doc}\n\n"
-		e.title = cmd.qualified_name
-		thumb = discord.File(
-			io.BytesIO(await self.bot.user.avatar_url_as(format="png").read()),
-			filename="thumb.png",
-		)
-		e.set_thumbnail(url="attachment://thumb.png")
-		e.set_footer(text=f"/{source_file}")
-		e.add_field(
-			name="Source Code",
-			value=f"[Open in Github]({link})",
-			inline=True,
-		)
-		await ctx.send(embed=e, file=thumb)
+		embed = discord.Embed(title=cmd.qualified_name,
+		                      description=f'[Open in Github]({link} "Github Repository Link")',)
+		embed.set_footer(
+			text=f"/{source_file}", icon_url='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png')
+		await ctx.send(embed=embed)
 
 
 def setup(bot):

--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -253,7 +253,7 @@ class Meta(AceMixin, commands.Cog):
 
 		await ctx.send(self.bot.support_link)
 
-	@commands.command(name="source", aliases=["src", "code"])
+	@commands.command(name="code", aliases=["src", "source"])
 	async def source(self, ctx: commands.Context, source_item: str = None):
 		"""Get a github link to the source code of a command."""
 
@@ -261,11 +261,9 @@ class Meta(AceMixin, commands.Cog):
 			await ctx.send(GITHUB_LINK)
 			return
 
-		# send a typing event while we get from github
-		# normally this would be an async with,
-		# but no reason to do so since it shouldn't take very long to do this code,
-		# therefore no reason to make it with.
-		# if its been long enough that it has to fire again we've errorer or send a response
+		# send a typing event 
+		# normally would be an async with,
+		# but no need to do so since it shouldn't take very long to do this code,
 		await ctx.trigger_typing()
 
 		cmd: commands.Command = self.bot.get_command(source_item)
@@ -276,8 +274,12 @@ class Meta(AceMixin, commands.Cog):
 		source_file = str(
 			Path(inspect.getsourcefile(callback)).relative_to(str(Path.cwd()))
 		)
-		if "internal" in source_file:
-			# hide all commands in cogs.ahk.internal
+
+		# get repo to check if its an ignored file
+		repo = pygit2.Repository('.git')
+
+		if pygit2.GIT_STATUS_IGNORED & repo.status_file(source_file):
+			# hide all commands in all git ignored files
 			raise commands.CommandError("Couldn't find command.")
 
 		lines, first_line_no = inspect.getsourcelines(callback)


### PR DESCRIPTION
This shows all commands, regardless of if they're hidden or not, and ignores the internal cogs by default. This means that any of the commands found on github can be viewed with the source command.

Also, this command now links to the github for all source requests. Some of the bot commands have long code, which would be spammy when invoked.

![image](https://user-images.githubusercontent.com/71233171/114400890-6babdd80-9b70-11eb-97f6-ecaf359209ac.png)
*Normal response*

![image](https://user-images.githubusercontent.com/71233171/114401134-a281f380-9b70-11eb-9876-4dcafc1b78e4.png)
*When no arguments passed*


![image](https://user-images.githubusercontent.com/71233171/114401230-b7f71d80-9b70-11eb-979d-d19bfe687c40.png)
*If the bot doesn't have perms to send a message in a channel.*

![image](https://i.imgur.com/uXjxt62.gif)
*Previous command could be spammy with some commands.*

![image](https://user-images.githubusercontent.com/71233171/114402108-83d02c80-9b71-11eb-98ff-9e17b7397aa7.png)
*Not anymore!*