### PR TITLE
Use allowed_mentions when sending user input

### DIFF
--- a/ace.py
+++ b/ace.py
@@ -331,7 +331,8 @@ async def setup():
 	# create allowed mentions
 	log.debug('Creating allowed mentions')
 	allowed_mentions = discord.AllowedMentions.none()
-	allowed_mentions.users= True
+	allowed_mentions.users = True
+	allowed_mentions.replied_user = True
 
 	# init bot
 	log.info('Initializing bot')

--- a/ace.py
+++ b/ace.py
@@ -328,9 +328,14 @@ async def setup():
 	log.info('Creating postgres pool')
 	db = await asyncpg.create_pool(DB_BIND)
 
+	# create allowed mentions
+	log.debug('Creating allowed mentions')
+	allowed_mentions = discord.AllowedMentions.none()
+	allowed_mentions.users= True
+
 	# init bot
 	log.info('Initializing bot')
-	bot = AceBot(db=db, loop=loop, intents=BOT_INTENTS)
+	bot = AceBot(db=db, loop=loop, intents=BOT_INTENTS, allowed_mentions=allowed_mentions)
 
 	# start it
 	log.info('Logging in and starting bot')

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -384,7 +384,8 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 
 			await channel.send(
 				content=author.mention,
-				embed=self._make_yell_embed(c)
+				embed=self._make_yell_embed(c),
+				allowed_mentions=discord.AllowedMentions(users=[author])
 			)
 
 			self.bot.dispatch(

--- a/cogs/remind.py
+++ b/cogs/remind.py
@@ -139,7 +139,7 @@ class Reminders(AceMixin, commands.Cog):
 
 		try:
 			if channel is not None:
-				await channel.send(content=f'<@{user_id}>', embed=e)
+				await channel.send(content=f'<@{user_id}>', embed=e, allowed_mentions=discord.AllowedMentions(users=True))
 			elif user is not None:
 				await user.send(embed=e)
 		except discord.HTTPException as exc:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -219,7 +219,7 @@ class Tags(AceMixin, commands.Cog):
 			return
 
 		tag_name, record = tag_name
-		await ctx.send(record.get('content'),allowed_mentions=discord.AllowedMentions.none())
+		await ctx.send(record.get('content'), allowed_mentions=discord.AllowedMentions.none())
 
 		await self.db.execute(
 			'UPDATE tag SET uses=$2, viewed_at=$3 WHERE id=$1',
@@ -363,7 +363,8 @@ class Tags(AceMixin, commands.Cog):
 		'''View raw contents of a tag. Useful when editing tags.'''
 
 		tag_name, record = tag_name
-		await ctx.send(discord.utils.escape_markdown(record.get('content')))
+		await ctx.send(discord.utils.escape_markdown(record.get('content')), 
+						allowed_mentions=discord.AllowedMentions.none())
 
 	@tag.command()
 	@can_prompt()
@@ -462,7 +463,9 @@ class Tags(AceMixin, commands.Cog):
 		res = await self.db.execute('UPDATE tag SET user_id=$1 WHERE id=$2', new_owner.id, record.get('id'))
 
 		if res == 'UPDATE 1':
-			await ctx.send('Tag \'{}\' transferred to \'{}\''.format(record.get('name'), new_owner.display_name))
+			await ctx.send('Tag \'{}\' transferred to \'{}\''.format(record.get('name'), new_owner.display_name), 
+							allowed_mentions=discord.AllowedMentions.none())
+
 		else:
 			raise commands.CommandError('Unknown error occured.')
 

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -219,7 +219,7 @@ class Tags(AceMixin, commands.Cog):
 			return
 
 		tag_name, record = tag_name
-		await ctx.send(record.get('content'))
+		await ctx.send(record.get('content'),allowed_mentions=discord.AllowedMentions.none())
 
 		await self.db.execute(
 			'UPDATE tag SET uses=$2, viewed_at=$3 WHERE id=$1',
@@ -227,7 +227,7 @@ class Tags(AceMixin, commands.Cog):
 		)
 
 	@tag.command(aliases=['add', 'new'])
-	async def create(self, ctx, tag_name: tag_create_converter, *, content: commands.clean_content = None):
+	async def create(self, ctx, tag_name: tag_create_converter, *, content: str = None):
 		'''Create a new tag.'''
 
 		await self.create_tag(ctx, tag_name, self.craft_tag_contents(ctx, content))
@@ -235,7 +235,7 @@ class Tags(AceMixin, commands.Cog):
 
 	@tag.command()
 	@can_prompt()
-	async def edit(self, ctx, tag_name: TagEditConverter(), *, new_content: commands.clean_content = None):
+	async def edit(self, ctx, tag_name: TagEditConverter(), *, new_content: str = None):
 		'''Edit an existing tag.'''
 
 		tag_name, record = tag_name
@@ -344,7 +344,7 @@ class Tags(AceMixin, commands.Cog):
 			if content is None:
 				old_message = ctx.message
 				ctx.message = message
-				content = self.craft_tag_contents(ctx, await commands.clean_content().convert(ctx, message.content))
+				content = self.craft_tag_contents(ctx, message.content)
 				ctx.message = old_message
 				break
 


### PR DESCRIPTION
A few quick fixes to prevent abuse mentioning users.

![image](https://user-images.githubusercontent.com/71233171/115773603-835c4080-a37e-11eb-890d-5bedee57c5b5.png)



#### Important Note:
The tag cog has been modified to now store content without cleaning mentions as `allowed_mentions` is utilized to show the tag contents.