### PR TITLE
[Bugfix] Gracefully error wolfram when no pods return

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -183,8 +183,7 @@ class Fun(AceMixin, commands.Cog):
 			'appid': WOLFRAM_KEY,
 			'input': query,
 			'output': 'json',
-			'ip': '1.1.1.1',
-			'latlong': '0.0,0.0',
+			'ip': '',
 			'units': 'metric',
 			'format': 'plaintext',
 		}
@@ -213,6 +212,11 @@ class Fun(AceMixin, commands.Cog):
 			e = discord.Embed(color=0xFF6600)
 			e.set_author(name='Wolfram|Alpha', icon_url='https://i.imgur.com/KFppH69.png')
 			e.set_footer(text='wolframalpha.com')
+
+			try:
+				res['pods']
+			except KeyError:
+				success = False
 
 			if not success:
 				e.description = 'Sorry, Wolfram Alpha was not able to parse your request.'

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -186,7 +186,7 @@ class Fun(AceMixin, commands.Cog):
 			'ip': '',
 			'units': 'metric',
 			'format': 'plaintext',
-			# 'podindex': '1,2,3'
+			'podindex': '1,2,3'
 		}
 
 		headers = {
@@ -208,7 +208,7 @@ class Fun(AceMixin, commands.Cog):
 			j = loads(j)
 			res = j['queryresult']
 
-			success = bool(res['success'] and res['numpods'])
+			success = res['success'] and res['numpods']
 
 			e = discord.Embed(color=0xFF6600)
 			e.set_author(name='Wolfram|Alpha', icon_url='https://i.imgur.com/KFppH69.png')
@@ -224,12 +224,13 @@ class Fun(AceMixin, commands.Cog):
 				if 'tips' in res:
 					e.add_field(name='Tips from Wolfram Alpha:', value=res['tips']['text'], inline=False)
 
-				if len(e.fields) == 0 and res['numpods'] == 0:
-					e.add_field(name='Possible Reason:',
-									value=(
-										'Its possible this errored due to not providing a location.\n'
-										'Try providing a location within your query.'),
-									inline=False
+				if not e.fields and res['numpods'] == 0:
+					e.add_field(
+						name='Possible Reason:',
+						value=(
+							'Its possible this errored due to not providing a location.\n'
+							'Try providing a location within your query.'),
+						inline=False
 					)
 
 				await ctx.send(embed=e)

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -186,7 +186,7 @@ class Fun(AceMixin, commands.Cog):
 			'ip': '',
 			'units': 'metric',
 			'format': 'plaintext',
-			'podindex': '1,2,3'
+			# 'podindex': '1,2,3'
 		}
 
 		headers = {
@@ -216,21 +216,20 @@ class Fun(AceMixin, commands.Cog):
 
 			if not success:
 				e.description = 'Sorry, Wolfram Alpha was not able to parse your request.'
-
 				means = res.get('didyoumeans', None)
 				if means is not None:
 					val = ', '.join(x['val'] for x in means) if isinstance(means, list) else means['val']
-					e.add_field(name='Wolfram is having issues with these word(s):', value='```{0}```'.format(val))
+					e.add_field(name='Wolfram is having issues with these word(s):', value='```{0}```'.format(val), inline=False)
 
 				if 'tips' in res:
-					e.add_field(name='Tips from Wolfram Alpha:', value=res['tips']['text'])
+					e.add_field(name='Tips from Wolfram Alpha:', value=res['tips']['text'], inline=False)
 
-				if res['numpods'] == 0:
-					e.add_field(name='Possible Reason:', 
-					value=(
-						'Its possible this errored due to not providing a location.\n'
-						'Try providing a location within your query.\n'
-						'*This message was not provided by wolfram.*')
+				if len(e.fields) == 0 and res['numpods'] == 0:
+					e.add_field(name='Possible Reason:',
+									value=(
+										'Its possible this errored due to not providing a location.\n'
+										'Try providing a location within your query.'),
+									inline=False
 					)
 
 				await ctx.send(embed=e)

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -186,6 +186,7 @@ class Fun(AceMixin, commands.Cog):
 			'ip': '',
 			'units': 'metric',
 			'format': 'plaintext',
+			'podindex': '1,2,3'
 		}
 
 		headers = {
@@ -207,16 +208,11 @@ class Fun(AceMixin, commands.Cog):
 			j = loads(j)
 			res = j['queryresult']
 
-			success = res['success']
+			success = bool(res['success'] and res['numpods'])
 
 			e = discord.Embed(color=0xFF6600)
 			e.set_author(name='Wolfram|Alpha', icon_url='https://i.imgur.com/KFppH69.png')
 			e.set_footer(text='wolframalpha.com')
-
-			try:
-				res['pods']
-			except KeyError:
-				success = False
 
 			if not success:
 				e.description = 'Sorry, Wolfram Alpha was not able to parse your request.'
@@ -228,6 +224,14 @@ class Fun(AceMixin, commands.Cog):
 
 				if 'tips' in res:
 					e.add_field(name='Tips from Wolfram Alpha:', value=res['tips']['text'])
+
+				if res['numpods'] == 0:
+					e.add_field(name='Possible Reason:', 
+					value=(
+						'Its possible this errored due to not providing a location.\n'
+						'Try providing a location within your query.\n'
+						'*This message was not provided by wolfram.*')
+					)
 
 				await ctx.send(embed=e)
 				return

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -183,7 +183,8 @@ class Fun(AceMixin, commands.Cog):
 			'appid': WOLFRAM_KEY,
 			'input': query,
 			'output': 'json',
-			'ip': '',
+			'ip': '1.1.1.1',
+			'latlong': '0.0,0.0',
 			'units': 'metric',
 			'format': 'plaintext',
 		}
@@ -201,6 +202,8 @@ class Fun(AceMixin, commands.Cog):
 					j = await resp.text()
 			except asyncio.TimeoutError:
 				raise QUERY_ERROR
+
+			log.debug(resp.url)
 
 			j = loads(j)
 			res = j['queryresult']


### PR DESCRIPTION
# Bugfix

As of now, location based queries to wolfram alpha error because the ip address provided is empty.
![image](https://user-images.githubusercontent.com/71233171/115802192-6f2f3800-a3ac-11eb-8df4-b062bed2d7fd.png)

This solves that issue by providing a mock ip address of cloudfare's dns servers, 1.1.1.1, and by giving a latitude and longitude of 0 degrees.
![image](https://user-images.githubusercontent.com/71233171/115802183-676f9380-a3ac-11eb-9aa0-a8ec81df7ca1.png)
