### PR TITLE
catch an edge case in no-reply implementation in ahk

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -366,13 +366,10 @@ class AutoHotkey(AceMixin, commands.Cog):
 		with open(filename, 'w', encoding='utf-8-sig') as f:
 			f.write('{0}\n\nLANG: {1}\n\nCODE:\n{2}\n\nPROCESSING TIME: {3}\n\nSTDOUT:\n{4}\n'.format(ctx.stamp, lang, code, time, stdout))
 
-		# because of how the api works, if the person has deleted their message then
-		# the api won't take the request and returns an error, so we catch it and don't
-		# reply. This ensures the output gets sent even if they delete their message.
-		try:
-			await ctx.reply(content=resp, file=file)
-		except discord.HTTPException:
-			await ctx.send(content=resp, file=file)
+		reference = ctx.message.to_reference()
+		reference.fail_if_not_exists = False
+		await ctx.send(content=resp, file=file, reference=reference)
+
 
 	@commands.command()
 	@commands.cooldown(rate=1, per=5.0, type=commands.BucketType.user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py==1.7.1
+discord.py==1.7.2
 asyncpg==0.20.1
 aiohttp==3.7.4
 fuzzywuzzy==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py==1.6.0
+discord.py==1.7.1
 asyncpg==0.20.1
 aiohttp==3.7.4
 fuzzywuzzy==0.18.0


### PR DESCRIPTION
# Description
In the edge case of the replied to message being lost/decached/deleted and unable to be referenced, file objects would silently error,
![image](https://user-images.githubusercontent.com/71233171/116135175-cbd96e00-a69e-11eb-981b-b63fe7fd72dd.png "message failing to upload properly and is an empty file")

As the person who implemented this code, this is a fix for my previously shoddy implementation.

# Dependency Bumps
This does require a discord.py version bump to [1.7.1](https://discordpy.readthedocs.io/en/stable/whats_new.html#v1-7-1 "Link to changelog"), in order to use [`fail_if_not_exists`](https://discordpy.readthedocs.io/en/stable/api.html#discord.MessageReference.fail_if_not_exists "fail if not exists documentation")