### PR TITLE
catch Reactions blocked on emoji suggestions

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -199,8 +199,10 @@ class AutoHotkey(AceMixin, commands.Cog):
 			# it could be that person is blocked, but it also could be that the bot doesn't have perms
 			# we treat it the same since this is only used in the ahk discord.
 			if e.text == 'Reaction blocked':
-				return await delete("I must be able to add reactions to your message! "
-									"If I'm blocked, you'll need to unblock me!")
+				return await delete(
+					'I must be able to add reactions to your message!\n'
+					"If I'm blocked, you'll need to unblock me!"
+					)
 
 	@commands.Cog.listener('on_raw_message_edit')
 	async def handle_emoji_suggestion_message_edit(self, message: discord.RawMessageUpdateEvent):

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -84,6 +84,9 @@ class AutoHotkey(AceMixin, commands.Cog):
 
 		self.rss.start()
 
+	def cog_unload(self):
+		self.rss.cancel()
+
 	def parse_date(self, date_str):
 		date_str = date_str.strip()
 		return datetime.strptime(date_str[:-3] + date_str[-2:], "%Y-%m-%dT%H:%M:%S%z")
@@ -188,8 +191,16 @@ class AutoHotkey(AceMixin, commands.Cog):
 				return await delete('Please do not suggest emojis that have already been added.')
 
 		# Add voting reactions
-		await message.add_reaction('✅')
-		await message.add_reaction('❌')
+		try:
+			await message.add_reaction('✅')
+			await message.add_reaction('❌')
+		except discord.Forbidden as e:
+			# catch if we can't add the reactions
+			# it could be that person is blocked, but it also could be that the bot doesn't have perms
+			# we treat it the same since this is only used in the ahk discord.
+			if e.text == 'Reaction blocked':
+				return await delete("I must be able to add reactions to your message! "
+									"If I'm blocked, you'll need to unblock me!")
 
 	@commands.Cog.listener('on_raw_message_edit')
 	async def handle_emoji_suggestion_message_edit(self, message: discord.RawMessageUpdateEvent):


### PR DESCRIPTION
Occasionally, people send emojis and have the bot blocked. This causes the bot to not react to their message, and throws internal errors.
![image](https://i.imgur.com/BKt2YlR.png)

I've added a try and except to prevent this from occuring.
![image](https://i.imgur.com/1HBLpqe.png)