### PR TITLE
Make Source Command Greedy Again

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -257,7 +257,7 @@ class Meta(AceMixin, commands.Cog):
 		await ctx.send(self.bot.support_link)
 
 	@commands.command(aliases=['source'])
-	async def code(self, ctx: AceContext, command: str = None):
+	async def code(self, ctx: AceContext, *, command: str = None):
 		"""Get a github link to the source code of a command."""
 
 		if command is None:


### PR DESCRIPTION
Left out a `*` in #32. This pr brings it back.