### PR TITLE
Development Friendly Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,40 @@
+# Byte-compiled / optimized / DLL files
 __pycache__
+
+# IDE Files
 .idea
 .vscode
+
+# Enviroment
+.env
+.venv
+env/
+venv/
+ENV/
+Pipfile
+Pipfile.lock
+
+# Ace Config
+config.py
+ids.py
+
+# Ace's data folders
 data
 error
 feedback
 logs
 ahk_eval
-venv
-config.py
+
+
+# Internal cogs
+cogs/ahk/internal
+
+# Game Model
 model
 tensorflow-2.3.1-cp37-cp37m-linux_x86_64.whl
 
+# Tests
 test.py
-ids.py
 test_md.py
 test_docs_parser.py
 notes.md
-cogs/ahk/internal

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,7 @@ Please install these according to their instructions.
   APIXU_KEY = None
 
   USE_GAME_MODEL = False
+  DEV_MODE = False
   ```
   * You can get your bot token from the [Discord Developer Portal](https://discord.com/developers/applications).
     If you haven't already:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,6 +68,8 @@ Please install these according to their instructions.
   THECATAPI_KEY = None
   WOLFRAM_KEY = None
   APIXU_KEY = None
+
+  USE_GAME_MODEL = False
   ```
   * You can get your bot token from the [Discord Developer Portal](https://discord.com/developers/applications).
     If you haven't already:

--- a/ace.py
+++ b/ace.py
@@ -21,7 +21,6 @@ from utils.string import po
 from utils.time import pretty_seconds
 
 EXTENSIONS = (
-	'cogs.owner',
 	'cogs.fun',
 	'cogs.configuration',
 	'cogs.tags',
@@ -39,6 +38,7 @@ EXTENSIONS = (
 	'cogs.ahk.internal.logger',
 	'cogs.ahk.internal.security',
 	'cogs.dwitter',
+	'cogs.owner',
 )
 
 
@@ -157,7 +157,7 @@ class AceBot(commands.Bot):
 		gc = await self.config.get_entry(message.guild.id)
 		return gc.prefix or DEFAULT_PREFIX
 
-	def load_extensions(self, reload: bool =False):
+	def load_extensions(self, reload: bool=False):
 		"""Reload bot Extensions. 
 
 		If `reload` is False, then cogs are unloaded and loaded.
@@ -195,6 +195,9 @@ class AceBot(commands.Bot):
 						reloaded.append(name)
 
 					except Exception as e:
+
+						if not DEV_MODE:
+							raise e
 
 						log.error(f'Failed to load extension: {name}')
 						log.error(e)

--- a/ace.py
+++ b/ace.py
@@ -199,7 +199,7 @@ class AceBot(commands.Bot):
 						log.error(f'Failed to load extension: {name}')
 						log.error(e)
 						errored.append((name, e.args[0].lstrip(f"Extension '{name}' raised an error:")))
-						traceback.print_tb(sys.exc_info()[2])
+						print("".join(traceback.format_exception(*sys.exc_info())).strip())
 
 		return reloaded, errored
 

--- a/ace.py
+++ b/ace.py
@@ -3,6 +3,7 @@ import json
 import logging.handlers
 import os
 import sys
+import traceback
 from datetime import datetime
 
 import aiohttp
@@ -169,12 +170,17 @@ class AceBot(commands.Bot):
 					if name in self.extensions.keys():
 						self.unload_extension(name)
 
-					log.debug('Loading %s', name)
+					try:
+						log.debug('Loading %s', name)
 
-					self.load_extension(name)
-					self.modified_times[name] = mtime
+						self.load_extension(name)
+						self.modified_times[name] = mtime
 
-					reloaded.append(name)
+						reloaded.append(name)
+					except Exception as e:
+						log.error(f'Failed to load extension: {name}')
+						log.error(e)
+						traceback.print_tb(sys.exc_info()[2])
 
 		return reloaded
 

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -8,14 +8,18 @@ from datetime import datetime, timedelta
 from json import JSONDecodeError, dumps, loads
 
 import discord
-import numpy as np
 import unidecode
 from discord.ext import commands, tasks
 
-log.info('Importing keras...')
-from tensorflow import keras
+from config import USE_GAME_MODEL
 
-log.info('Finished importing keras.')
+if USE_GAME_MODEL:
+	import numpy as np
+	log.info('Importing keras...')
+	from tensorflow import keras
+	log.info('Finished importing keras.')
+else:
+	log.info('keras.model has not been loaded.')
 
 from cogs.mixins import AceMixin
 from ids import ACTIVE_CATEGORY_ID, ACTIVE_INFO_CHAN_ID, AHK_GUILD_ID, CLOSED_CATEGORY_ID, GET_HELP_CHAN_ID, IGNORE_ACTIVE_CHAN_IDS, OPEN_CATEGORY_ID, \
@@ -97,11 +101,15 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 		self.claimed_messages = dict()
 
 		log.debug('Loading model')
-		self.model = keras.models.load_model('model')
+		if USE_GAME_MODEL:
+			self.model = keras.models.load_model('model')
 		log.debug('Finished loading model')
 
 	def classify(self, text):
-		return self.model(np.array([standardize(text)[0]])).numpy()[0][0]
+		if USE_GAME_MODEL:
+			return self.model(np.array([standardize(text)[0]])).numpy()[0][0]
+		else:
+			return 0
 
 	@property
 	def open_category(self):

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -14,9 +14,9 @@ from discord.ext import commands, tasks
 from config import USE_GAME_MODEL
 
 if USE_GAME_MODEL:
-	import numpy as np
+	import numpy as np  # type: ignore
 	log.info('Importing keras...')
-	from tensorflow import keras
+	from tensorflow import keras  # type: ignore
 	log.info('Finished importing keras.')
 else:
 	log.info('keras.model has not been loaded.')
@@ -100,10 +100,15 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 		self.channel_reclaimer.start()
 		self.claimed_messages = dict()
 
-		log.debug('Loading model')
+		
 		if USE_GAME_MODEL:
-			self.model = keras.models.load_model('model')
-		log.debug('Finished loading model')
+			log.debug('Loading model')
+			self.model = keras.models.load_model('model')  # type: ignore
+			log.debug('Finished loading model')
+		else:
+			log.info('Model is disabled.')
+			self.model = None
+		
 
 	def classify(self, text):
 		if USE_GAME_MODEL:

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -290,13 +290,25 @@ class Owner(AceMixin, commands.Cog):
 	async def _reload(self, ctx):
 		'''Reload edited extensions.'''
 
-		reloaded = self.bot.load_extensions()
+		reloaded, errored = self.bot.load_extensions(reload=True)
+		out = ''
+		if reloaded or errored:
+			if reloaded:
+				log.info('Reloaded cogs: %s', ', '.join(reloaded))
+				out += 'Reloaded cogs: ' + ', '.join('`{0}`'.format(ext) for ext in reloaded)
+			if errored:
+				# some cogs failed to reload
+				out += '\n\nThese cogs errored:```diff\n'
 
-		if reloaded:
-			log.info('Reloaded cogs: %s', ', '.join(reloaded))
-			await ctx.send('Reloaded cogs: ' + ', '.join('`{0}`'.format(ext) for ext in reloaded))
+				for e in errored:
+					log.error(f'{e[0]} failed to reload: {e[1]}')
+					out += f'- {e[0]}: {e[1]}'
+				out += '\n```'
+				out = out.strip('\n')
 		else:
 			await ctx.send('Nothing to reload.')
+
+		await ctx.send(out)
 
 	@commands.command()
 	async def decache(self, ctx, guild_id: int):


### PR DESCRIPTION
This pr is to patch a few settings to make ace a bit more development friendly.

### Changes Shortlist:
- modify the code to import the ml model in cogs.ahk.help to only be used if a config variable is True
- add try and except to the cog loading at start to make sure even if one cog errors the rest still load
- return a list of errored cogs when reloading them with the reload
- make the cog reload command use `reload_extension` when doing a cog reload and not `unload` followed `load`
- update .gitignore to ignore additional ide development files and .env files



![image](https://user-images.githubusercontent.com/71233171/116943492-ac63b780-ac41-11eb-9205-6c10bd635c44.png)
*New reload command response when reloading cogs*


### Env Updates:
Requires adding a bool `USE_GAME_MODEL` to your config.py file.