### PR TITLE
feat: restructure ace

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -131,8 +131,7 @@ you can get the ID of channels, categories, roles, etc. by right-clicking on the
 
 * Run `pip install -r requirements.txt`.
 * Run `python migrate.py` to setup all necessary databases automatically.
-* Create a folder called `logs`.
 
 ## That's it!
 
-You should be able to start the bot with `python ace.py`!
+You should be able to start the bot with `python main.py`!

--- a/ace.py
+++ b/ace.py
@@ -1,25 +1,24 @@
 import asyncio
-import json
 import logging.handlers
 import os
 from datetime import datetime
 
 import aiohttp
 import asyncpg
-import coloredlogs
+import disnake
 from disnake.ext import commands
 
 from config import *
-from utils.commanderrorlogic import CommandErrorLogic
 from utils.configtable import ConfigTable
 from utils.context import AceContext
 from utils.guildconfigrecord import GuildConfigRecord
 from utils.help import PaginatedHelpCommand
 from utils.string import po
-from utils.time import pretty_seconds
 
 EXTENSIONS = (
 	'cogs.test',
+	'cogs.backend.error_handler',
+	'cogs.backend.logger',
 	'cogs.fun',
 	'cogs.configuration',
 	'cogs.tags',
@@ -50,22 +49,27 @@ class AceBot(commands.Bot):
 	config: ConfigTable
 	startup_time: datetime
 
-	def __init__(self, db, **kwargs):
+	def __init__(self, **kwargs):
 		super().__init__(
 			command_prefix=self.prefix_resolver,
 			owner_id=OWNER_ID,
 			description=DESCRIPTION,
 			help_command=PaginatedHelpCommand(),
 			max_messages=20000,
-			activity=BOT_ACTIVITY,
+			activity=disnake.Game('Booting up...'),
+			status=disnake.Status.do_not_disturb,
 			**kwargs
 		)
 
-		self.db = db
+		# created in login
+		self.db = None
+
 		self.config = ConfigTable(self, table='config', primary='guild_id', record_class=GuildConfigRecord)
 
 		self.ready = asyncio.Event()
 		self.startup_time = datetime.utcnow()
+
+		self.log = logging.getLogger('acebot') 
 
 		aiohttp_log = logging.getLogger('aiotrace')
 
@@ -88,10 +92,10 @@ class AceBot(commands.Bot):
 		self.modified_times = dict()
 
 	async def on_connect(self):
-		log.info('Connected to gateway!')
+		self.log.info('Connected to gateway!')
 
 	async def on_resumed(self):
-		log.info('Reconnected to gateway!')
+		self.log.info('Reconnected to gateway!')
 
 		# re-set presence on connection resumed
 		await self.change_presence()
@@ -100,9 +104,10 @@ class AceBot(commands.Bot):
 	async def on_ready(self):
 		if not self.ready.is_set():
 			self.load_extensions()
+			await self.change_presence(activity=BOT_ACTIVITY, status=disnake.Status.online)
 
 			self.ready.set()
-			log.info('Ready! %s', po(self.user))
+			self.log.info('Ready! %s', po(self.user))
 
 	async def on_message(self, message):
 		# ignore DMs and bot accounts
@@ -156,7 +161,7 @@ class AceBot(commands.Bot):
 					if name in self.extensions.keys():
 						self.unload_extension(name)
 
-					log.debug('Loading %s', name)
+					self.log.debug('Loading %s', name)
 
 					self.load_extension(name)
 					self.modified_times[name] = mtime
@@ -165,53 +170,7 @@ class AceBot(commands.Bot):
 
 		return reloaded
 
-	async def on_command(self, ctx):
-		spl = ctx.message.content.split('\n')
-		log.info('%s in %s: %s', po(ctx.author), po(ctx.guild), spl[0] + (' ...' if len(spl) > 1 else ''))
 
-	async def on_command_completion(self, ctx: AceContext):
-		await ctx.db.execute(
-			'INSERT INTO log (guild_id, channel_id, user_id, timestamp, command) VALUES ($1, $2, $3, $4, $5)',
-			ctx.guild.id, ctx.channel.id, ctx.author.id, datetime.utcnow(), ctx.command.qualified_name
-		)
-
-	async def on_command_error(self, ctx, exc):
-		async with CommandErrorLogic(ctx, exc) as handler:
-			if isinstance(exc, commands.CommandInvokeError):
-				if isinstance(exc.original, disnake.HTTPException):
-					log.debug('Command failed with %s', str(exc.original))
-					return
-				handler.oops()
-
-			elif isinstance(exc, commands.ConversionError):
-				handler.oops()
-
-			elif isinstance(exc, commands.UserInputError):
-				handler.set(
-					title=str(exc),
-					description='Usage: `{0.prefix}{1.qualified_name} {1.signature}`'.format(ctx, ctx.command)
-				)
-
-			elif isinstance(exc, commands.DisabledCommand):
-				handler.set(description='Sorry, command has been disabled by owner. Try again later!')
-
-			elif isinstance(exc, commands.CommandOnCooldown):
-				handler.set(
-					title='You are on cooldown.',
-					description='Try again in {0}.'.format(pretty_seconds(exc.retry_after))
-				)
-
-			elif isinstance(exc, commands.BotMissingPermissions):
-				handler.set(description=str(exc))
-
-			elif isinstance(exc, (commands.CheckFailure, commands.CommandNotFound)):
-				return
-
-			elif isinstance(exc, commands.CommandError):
-				handler.set(description=str(exc))
-
-			elif isinstance(exc, disnake.DiscordException):
-				handler.oops()
 
 	@property
 	def invite_link(self):
@@ -219,83 +178,13 @@ class AceBot(commands.Bot):
 			self.user.id, 268823632
 		)
 
-
-def setup_logger():
-	# init first log file
-	if not os.path.isfile('logs/log.log'):
-		open('logs/log.log', 'w+')
-
-	# set logging levels for various libs
-	logging.getLogger('disnake').setLevel(logging.INFO)
-	logging.getLogger('websockets').setLevel(logging.INFO)
-	logging.getLogger('asyncpg').setLevel(logging.INFO)
-	logging.getLogger('asyncio').setLevel(logging.INFO)
-
-	# we want out logging formatted like this everywhere
-	fmt = logging.Formatter('{asctime} [{levelname}] {name}: {message}', datefmt='%Y-%m-%d %H:%M:%S', style='{')
-
-	coloredlogs.install(
-		level=LOG_LEVEL,
-		fmt='{asctime} [{levelname}] {name}: {message}',
-		style='{',
-		level_styles=dict(debug=dict(color=12), info=dict(color=15), warning=dict(bold=True, color=13), critical=dict(bold=True, color=9))
-
-	)
-
-	file = logging.handlers.TimedRotatingFileHandler('logs/log.log', when='midnight', encoding='utf-8-sig')
-	file.setFormatter(fmt)
-	file.setLevel(logging.INFO)
-
-	# get the __main__ logger and add handlers
-	root = logging.getLogger()
-	root.setLevel(LOG_LEVEL)
-	root.addHandler(file)
-
-	return logging.getLogger(__name__)
-
-
-async def setup():
-	# create folders
-	for path in ('data', 'logs', 'error', 'feedback', 'ahk_eval'):
-		if not os.path.exists(path):
-			log.info('Creating folder: %s', path)
-			os.makedirs(path)
-
-	# misc. monkey-patching
-	class Embed(disnake.Embed):
-		def __init__(self, color=disnake.Color.blue(), **attrs):
-			attrs['color'] = color
-			super().__init__(**attrs)
-
-	disnake.Embed = Embed
-
-	def patched_execute(old):
-		async def new(self, query, args, limit, timeout, return_status=False):
-			log.debug(query)
-			return await old(self, query, args, limit, timeout, return_status)
-
-		return new
-
-	asyncpg.Connection._execute = patched_execute(asyncpg.Connection._execute)
-
-	# connect to db
-	log.info('Creating postgres pool')
-	db = await asyncpg.create_pool(DB_BIND)
-
-	# create allowed mentions
-	allowed_mentions = disnake.AllowedMentions(everyone=False, users=True, roles=False, replied_user=True)
-
-	# init bot
-	log.info('Initializing bot')
-	bot = AceBot(db=db, loop=loop, intents=BOT_INTENTS, allowed_mentions=allowed_mentions, test_guilds=TEST_GUILDS)
-
-	# start it
-	log.info('Logging in and starting bot')
-	await bot.start(BOT_TOKEN)
-
+	async def login(self, token: str) -> None:
+		self.log.info('Creating postgres pool')
+		self.db = await asyncpg.create_pool(DB_BIND)
+		self.log.info('Logging in to discord')
+		return await super().login(token)
 
 if __name__ == '__main__':
-	log = setup_logger()
-	loop = asyncio.get_event_loop()
-
-	loop.run_until_complete(setup())
+	import sys
+	print('The entry point has moved, use main.py to run the bot now.')
+	sys.exit(1)

--- a/cogs/ahk/help.py
+++ b/cogs/ahk/help.py
@@ -124,6 +124,14 @@ class AutoHotkeyHelpSystem(AceMixin, commands.Cog):
 			if pivot < on_age:
 				await self.close_channel(channel)
 
+	@channel_reclaimer.before_loop
+	async def _wait_until_ready(self):
+		await self.bot.wait_until_ready()
+
+	def cog_unload(self) -> None:
+		self.channel_reclaimer.cancel()
+		return super().cog_unload()
+
 	@commands.command(hidden=True)
 	@is_mod()
 	async def open(self, ctx, channel: disnake.TextChannel):

--- a/cogs/backend/error_handler.py
+++ b/cogs/backend/error_handler.py
@@ -1,0 +1,53 @@
+import disnake
+from ace import AceBot
+from cogs.mixins import AceMixin
+from disnake.ext import commands
+from utils.commanderrorlogic import CommandErrorLogic
+from utils.context import AceContext
+from utils.time import pretty_seconds
+
+
+class ErrorHandler(commands.Cog, AceMixin):
+	@commands.Cog.listener()
+	async def on_command_error(self, ctx: AceContext, exc):
+		'''Handle command errors.'''
+		async with CommandErrorLogic(ctx, exc) as handler:
+			if isinstance(exc, commands.CommandInvokeError):
+				if isinstance(exc.original, disnake.HTTPException):
+					self.bot.log.debug('Command failed with %s', str(exc.original))
+					return
+				handler.oops()
+
+			elif isinstance(exc, commands.ConversionError):
+				handler.oops()
+
+			elif isinstance(exc, commands.UserInputError):
+				handler.set(
+					title=str(exc),
+					description='Usage: `{0.prefix}{1.qualified_name} {1.signature}`'.format(ctx, ctx.command),
+				)
+
+			elif isinstance(exc, commands.DisabledCommand):
+				handler.set(description='Sorry, command has been disabled by owner. Try again later!')
+
+			elif isinstance(exc, commands.CommandOnCooldown):
+				handler.set(
+					title='You are on cooldown.',
+					description='Try again in {0}.'.format(pretty_seconds(exc.retry_after)),
+				)
+
+			elif isinstance(exc, commands.BotMissingPermissions):
+				handler.set(description=str(exc))
+
+			elif isinstance(exc, (commands.CheckFailure, commands.CommandNotFound)):
+				return
+
+			elif isinstance(exc, commands.CommandError):
+				handler.set(description=str(exc))
+
+			elif isinstance(exc, disnake.DiscordException):
+				handler.oops()
+
+
+def setup(bot: AceBot):
+	bot.add_cog(ErrorHandler(bot))

--- a/cogs/backend/logger.py
+++ b/cogs/backend/logger.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from typing import Union
+
+import disnake
+from ace import AceBot
+from cogs.mixins import AceMixin
+from disnake.ext import commands
+from utils.context import AceContext
+from utils.string import po
+
+
+class InternalLogger(commands.Cog, AceMixin):
+	
+	@commands.Cog.listener()
+	async def on_command(self, ctx: Union[AceContext, disnake.Interaction]):
+		spl = ctx.message.content.split('\n')
+		self.bot.log.info('%s in %s: %s', po(ctx.author), po(ctx.guild), spl[0] + (' ...' if len(spl) > 1 else ''))
+	
+	@commands.Cog.listener()
+	async def on_command_completion(self, ctx: Union[AceContext, disnake.Interaction]):
+		await self.bot.db.execute(
+			'INSERT INTO log (guild_id, channel_id, user_id, timestamp, command) VALUES ($1, $2, $3, $4, $5)',
+			ctx.guild.id, ctx.channel.id, ctx.author.id, datetime.utcnow(), ctx.command.qualified_name
+		)
+
+def setup(bot: AceBot):
+	bot.add_cog(InternalLogger(bot))

--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -84,11 +84,14 @@ class Starboard(AceMixin, commands.Cog):
 		'''
 
 		self.purger.start()
+	
+	def cog_unload(self) -> None:
+		self.purger.cancel()
 
 	@tasks.loop(minutes=20)
 	async def purger(self):
 		'''Purges old and underperforming stars depending on guild starboard settings.'''
-
+		await self.bot.wait_until_ready()
 		boards = await self.db.fetch(
 			'SELECT guild_id, channel_id, threshold FROM starboard WHERE locked IS FALSE AND threshold IS NOT NULL'
 		)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,107 @@
+import asyncio
+import logging.handlers
+import os
+
+import asyncpg
+import coloredlogs
+import disnake
+
+from ace import AceBot
+from config import BOT_INTENTS, BOT_TOKEN, LOG_LEVEL, TEST_GUILDS
+
+
+def setup_logger():
+	# init first log file
+	if not os.path.isfile('logs/log.log'):
+		# we have to make the logs dir before we log to it
+		if not os.path.exists('logs'):
+			os.makedirs('logs')
+		open('logs/log.log', 'w+')
+
+	# set logging levels for various libs
+	logging.getLogger('disnake').setLevel(logging.INFO)
+	logging.getLogger('websockets').setLevel(logging.INFO)
+	logging.getLogger('asyncpg').setLevel(logging.INFO)
+	logging.getLogger('asyncio').setLevel(logging.INFO)
+
+	# we want out logging formatted like this everywhere
+	fmt = logging.Formatter(
+		'{asctime} [{levelname}] {name}: {message}', datefmt='%Y-%m-%d %H:%M:%S', style='{'
+	)
+
+	coloredlogs.install(
+		level=logging.DEBUG,
+		fmt='{asctime} [{levelname}] {name}: {message}',
+		style='{',
+		level_styles=dict(
+			debug=dict(color=12),
+			info=dict(color=15),
+			warning=dict(bold=True, color=13),
+			critical=dict(bold=True, color=9),
+		),
+	)
+
+	file = logging.handlers.TimedRotatingFileHandler(
+		'logs/log.log', when='midnight', encoding='utf-8-sig'
+	)
+	file.setFormatter(fmt)
+	file.setLevel(logging.INFO)
+
+	# get the __main__ logger and add handlers
+	root = logging.getLogger()
+	root.setLevel(LOG_LEVEL)
+	root.addHandler(file)
+
+	return logging.getLogger(__name__)
+
+
+def setup():
+	# create folders
+	for path in ('data', 'error', 'feedback', 'ahk_eval'):
+		if not os.path.exists(path):
+			log.info('Creating folder: %s', path)
+			os.makedirs(path)
+
+	# misc. monkey-patching
+	class Embed(disnake.Embed):
+		def __init__(self, color=disnake.Color.blue(), **attrs):
+			attrs['color'] = color
+			super().__init__(**attrs)
+
+	disnake.Embed = Embed
+
+	def patched_execute(old):
+		async def new(self, query, args, limit, timeout, return_status=False):
+			log.debug(query)
+			return await old(self, query, args, limit, timeout, return_status)
+
+		return new
+
+	asyncpg.Connection._execute = patched_execute(asyncpg.Connection._execute)
+
+	# create allowed mentions
+	allowed_mentions = disnake.AllowedMentions(
+		everyone=False,
+		users=True,
+		roles=False,
+		replied_user=True,
+	)
+
+	# init bot
+	log.info('Initializing bot')
+	bot = AceBot(
+		loop=loop,
+		intents=BOT_INTENTS,
+		allowed_mentions=allowed_mentions,
+		test_guilds=TEST_GUILDS,
+	)
+
+	return bot
+
+
+if __name__ == '__main__':
+	log = setup_logger()
+	loop = asyncio.get_event_loop()
+
+	bot = setup()
+	bot.run(BOT_TOKEN)

--- a/utils/context.py
+++ b/utils/context.py
@@ -1,10 +1,14 @@
-import disnake
 import asyncio
+from typing import TYPE_CHECKING
 
+import disnake
 from disnake.ext import commands
 
-from utils.time import pretty_datetime
 from utils.string import po
+from utils.time import pretty_datetime
+
+if TYPE_CHECKING:
+	from ace import AceBot
 
 STATIC_PERMS = ('add_reactions', 'manage_messages', 'embed_links')
 PROMPT_REQUIRED_PERMS = ('embed_links', 'add_reactions')
@@ -36,6 +40,7 @@ def can_prompt():
 class AceContext(commands.Context):
 	def __init__(self, **kwargs):
 		super().__init__(**kwargs)
+		self.bot: 'AceBot'
 
 	@property
 	def db(self):


### PR DESCRIPTION
- move the code that runs ace to a seperate file, main.py
- use disnake.ext.commands.Bot.run() to run the bot
  this has an advantage of automatically installing signal handlers
  which means that the bot no longer throws keyboard interrupt errors on exit
- move the error handler to a seperate cog
  needs to be expanded to support interactions, so moving it makes it easier to iterate upon
- typehint the custom context's bot
- create the database connection in the bot's login method
  this allows the use of Bot.run() to run the bot.
