### PR TITLE
fix: echo the user's query in docs autocomplete

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -373,7 +373,10 @@ class AutoHotkey(AceMixin, commands.Cog):
 
 	@slash_docs.autocomplete('query')
 	async def docs_autocomplete(self, inter: disnake.AppCommandInter, query: str):
-		return self.search_docs(query, k=SEARCH_COUNT, make_default=True)
+		res = self.search_docs(query, k=SEARCH_COUNT, make_default=True) or []
+		if query:
+			res.insert(0, query)
+		return res
 
 	def search_docs(self, query, k=8, make_default=False):
 		query = query.strip().lower()


### PR DESCRIPTION
this allows them to select what they type, since not all searches are currently shown to the user