### PR TITLE
feat: add msdn slash command

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -515,7 +515,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 			'$top': 1,
 		}
 
-		async with ctx.http.get(url, params=params) as resp:
+		async with self.bot.aiohttp.get(url, params=params, timeout=2) as resp:
 			if resp.status != 200:
 				raise commands.CommandError('Query failed.')
 
@@ -541,6 +541,22 @@ class AutoHotkey(AceMixin, commands.Cog):
 		e.set_footer(text='docs.microsoft.com', icon_url='https://i.imgur.com/UvkNAEh.png')
 
 		await ctx.send(embed=e)
+
+	@commands.slash_command(name='msdn')
+	async def slash_msdn(self, inter: disnake.CommandInteraction, query: str):
+		'''
+		Search the Microsoft documentation.
+		
+		Parameters
+		----------
+		query: query
+		'''
+		await self.msdn(inter, query=query)
+
+	@slash_msdn.error
+	async def slash_msdn_error(self, inter: disnake.CommandInteraction, exc):
+		if isinstance(exc, commands.CommandError):
+			await inter.send(embed=disnake.Embed(description=str(exc)), ephemeral=True)
 
 	@commands.command()
 	async def version(self, ctx):


### PR DESCRIPTION
Add an msdn slash command to search microsoft documentation.


Examples:

![image](https://user-images.githubusercontent.com/71233171/149490759-a080ee12-f3b0-42dc-91e2-046351251f6c.png)


![image](https://user-images.githubusercontent.com/71233171/149490778-45798818-e6e5-4cc2-8bc3-9f728cd79f85.png)
