### PR TITLE
In ahk cog use ansi highlight on response

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -314,7 +314,7 @@ class AutoHotkey(AceMixin, commands.Cog):
 				# upload as plaintext
 				stdout = stdout.replace('``', '`\u200b`')
 
-				resp = '```autoit\n{0}\n```{1}'.format(
+				resp = '```ansi\n{0}\n```{1}'.format(
 					stdout if stdout else 'No output.',
 					display_time
 				)


### PR DESCRIPTION
Discord desktop recently rolled out a new highlighter for ANSI escape codes, allowing richer display of outputs including those control sequences. This could be useful for richer display of the output from shell programs, to let people toy with building custom highlighters, to let the back end service provide richer error messages, or simply to make the command more fun.

Alternatively, we could use the default language set by the user with the `lang` command. However, I'm not sure the increased complexity is needed given that the result of a command is rarely ever code itself.