### PR TITLE
Fall back to h3 elements (from h2) when parsing docs headers

### DIFF
--- a/utils/docs_parser/handlers.py
+++ b/utils/docs_parser/handlers.py
@@ -372,7 +372,7 @@ class MethodListParser(BaseParser):
 
 		for tag in self.bs.find_all('div', id=True):
 			_id = tag.get('id')
-			header = tag.find('h2')
+			header = tag.find('h2') or tag.find('h3')
 			names = self.tag_as_names(header)
 
 			desc, syntax = self.get_desc_and_syntax(header)


### PR DESCRIPTION
Since https://github.com/Lexikos/AutoHotkey_L-Docs/commit/716bc0a5743e1d20c65231eabd57dfc2f4c1a166 (and possibly others), some pages use `h3` elements where previously `h2` was used. This causes the `.build` command to fail.
This PR fixes that.
After merging this PR, `.build` should work again.