### PR TITLE
feat: use buttons for trivia command

### DIFF
--- a/cogs/games.py
+++ b/cogs/games.py
@@ -189,12 +189,11 @@ class TriviaQuestion:
         return BOOLEAN_MAP if self.type == "boolean" else MULTIPLE_MAP
 
     def to_embed(self) -> disnake.Embed:
-        option_emojis = BOOLEAN_MAP if self.type == "boolean" else MULTIPLE_MAP
         question_string = "{}\n\n{}\n".format(
             self.question,
             "\n".join(
                 "{} {}".format(emoji, option)
-                for emoji, option in zip(option_emojis, self.options)
+                for emoji, option in zip(self.option_emojis, self.options)
             ),
         )
         e = disnake.Embed(

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -173,7 +173,6 @@ class TriviaQuestion:
                 disnake.ui.Button(
                     style=disnake.ButtonStyle.primary,
                     label=option,
-                    emoji=emoji,
                     custom_id=TRIVIA_CUSTOM_ID_PREFIX + "ans_choices:" + emoji,
                 )
             )
@@ -205,7 +204,7 @@ class TriviaQuestion:
             ),
             color=DIFFICULTY_COLORS[self.difficulty],
         )
-        e.add_field(name="Question", value=question_string, inline=False)
+        e.add_field(name="Question", value=self.question, inline=False)
         return e
 
 
@@ -428,7 +427,7 @@ class Games(AceMixin, commands.Cog):
                             continue
                         if component.custom_id == interaction.component.custom_id:
                             component.style = disnake.ButtonStyle.red
-                        elif str(component.emoji) == question.correct_emoji:
+                        elif component.custom_id.removeprefix(TRIVIA_CUSTOM_ID_PREFIX + "ans_choices:") == question.correct_emoji:
                             component.style = disnake.ButtonStyle.green
 
                 await interaction.response.edit_message(components=components)

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -449,10 +449,11 @@ class Games(AceMixin, commands.Cog):
             except disnake.HTTPException:
                 pass
 
-            await ctx.send(
+            await msg.reply(
                 "Question timed out and you lost {} points. Answer within {} seconds next time!".format(
                     score, int(QUESTION_TIMEOUT)
-                )
+                ),
+                fail_if_not_exists=False,
             )
 
             await self._on_wrong(ctx, answered_at, question.hash, score)


### PR DESCRIPTION
Rather than emojis and reactions, we switch to using buttons for trivia. There is also more feedback on the answers themselves. 

This definitely needs some more work, but its fully functional. I'm just not sure about all of the UI, and those decisions affect the rest of the changes I make on the backend.

current form: notice the lack of emojis and the answers ONLY appear on the buttons
![image](https://user-images.githubusercontent.com/71233171/225827468-db7737e6-62ed-4792-8f59-999ca782ba82.png)

correct answers are in green (emojis don't exist on current version)
![image](https://user-images.githubusercontent.com/71233171/225827784-735c7a11-e11e-4e9e-9303-e0188a8cd046.png)

incorrect answers are in red, with the correct answer in green (emojis don't exist on current version)
![image](https://user-images.githubusercontent.com/71233171/225827811-25077452-eca4-4071-a5d0-ec2c8f88e02d.png)

if the question times out
![image](https://user-images.githubusercontent.com/71233171/225828713-bd82803f-9840-4271-be9d-acfc48eaaa29.png)


