### PR TITLE
Adding message to ahk help channels when owner leaves

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,6 +64,8 @@ Please install these according to their instructions.
   CLOUDAHK_USER = None
   CLOUDAHK_PASS = None
 
+  DOCS_API_URL = None
+
   DBL_KEY = None
   THECATAPI_KEY = None
   WOLFRAM_KEY = None

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -919,6 +919,21 @@ class AutoHotkey(AceMixin, commands.Cog):
 
                     return
 
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: disnake.Member):
+        forum: disnake.ForumChannel = self.bot.get_channel(HELP_FORUM_CHAN_ID)
+
+        for thread in forum.threads:
+            if thread.owner_id != member.id:
+                continue
+            
+            if thread.archived:
+                continue
+            
+            if thread.locked:
+                continue
+            
+            await thread.send("❕ The thread owner is no longer in this server.")
 
 def setup(bot):
     bot.add_cog(AutoHotkey(bot))

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -923,6 +923,9 @@ class AutoHotkey(AceMixin, commands.Cog):
     async def on_member_remove(self, member: disnake.Member):
         forum: disnake.ForumChannel = self.bot.get_channel(HELP_FORUM_CHAN_ID)
 
+        if not forum:
+            return
+        
         for thread in forum.threads:
             if thread.owner_id != member.id:
                 continue
@@ -933,7 +936,7 @@ class AutoHotkey(AceMixin, commands.Cog):
             if thread.locked:
                 continue
             
-            await thread.send("❕ The thread owner is no longer in this server.")
+            await thread.send(embed=disnake.Embed(description="The thread owner is no longer in this server."))
 
 def setup(bot):
     bot.add_cog(AutoHotkey(bot))


### PR DESCRIPTION
When an user leaves the server, send a simple message in their owned threads informing people that they left.

This should be useful for helpers who would start putting effort into writing code or typing long explanations for a person who is not in the server because they were not aware of their absence.