### PR TITLE
Added optional attachment upload to p.autohotkey.com

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -969,9 +969,9 @@ class AutoHotkey(AceMixin, commands.Cog):
             encoding = "utf-8-sig"
 
             if isinstance(attachment.content_type, str):
-                charset = attachment.content_type.rpartition("charset=")[2].strip()
-                if charset:
-                    encoding = charset
+                charset = re.search(r"charset=([\w-]+)", attachment.content_type)
+                if charset is not None:
+                    encoding = charset.group(1)
 
             try:
                 decoded = data.decode(encoding)


### PR DESCRIPTION
When an user sends file attachments, give them an option to upload to https://p.autohotkey.com

Only works in the help forum and in the non-forum help channels.

Non text attachments are ignored.

https://github.com/user-attachments/assets/deedf9ac-e027-4ab3-927d-2ceb0dd22157