### PR TITLE
Better tagging

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -61,10 +61,6 @@ SKIP = disnake.PartialEmoji(name="⏩")
 DONE = disnake.PartialEmoji(name="☑️")
 
 
-def tag_string(tag):
-    return "- " + (tag.emoji.name + " " if tag.emoji else "") + tag.name + "\n"
-
-
 class RunnableCodeConverter(commands.Converter):
     async def convert(self, ctx, code):
         if code.startswith("https://p.ahkscript.org/"):
@@ -842,7 +838,7 @@ class AutoHotkey(AceMixin, commands.Cog):
             except asyncio.TimeoutError:
                 break
 
-            if len(result) > 1:
+            if isinstance(question, MultiSelect):
                 multi_tags.append(result)
             else:
                 added_tags += result
@@ -852,6 +848,9 @@ class AutoHotkey(AceMixin, commands.Cog):
         chosen_tags = added_tags[:5]
         ignored_tags = added_tags[5:]
         await thread.edit(applied_tags=chosen_tags)
+
+        def tag_string(tag):
+            return "- " + (tag.emoji.name + " " if tag.emoji else "") + tag.name + "\n"
 
         if added_tags:
             content = "Thanks for tagging your post!\nYou can change the tags at any time by using `/retag`\n\n"

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -213,11 +213,15 @@ class MultiSelect(TagAskState):
         result: set[disnake.ForumTag] = set()
 
         while True:
-            button = await self.wait()
-            assert button.label is not None
+            component = await self.wait()
+            assert component.label is not None
 
-            if button.label in ["Skip", "Done"]:
+            if component.label in ["Skip", "Done"]:
                 return result
+
+            button = self.label_to_component.get(component.label, None)
+            assert button is not None
+            assert button.label is not None
 
             tag = self.get_tag(button.label)
 
@@ -233,10 +237,9 @@ class MultiSelect(TagAskState):
                 result.add(tag)
                 button.style = disnake.ButtonStyle.primary
 
-                if not result:
-                    self.next_button.style = disnake.ButtonStyle.success
-                    self.next_button.label = "Done"
-                    self.next_button.emoji = DONE
+                self.next_button.style = disnake.ButtonStyle.success
+                self.next_button.label = "Done"
+                self.next_button.emoji = DONE
 
             await message.edit(content=None, **self.get_message_args())
 
@@ -838,15 +841,20 @@ class AutoHotkey(AceMixin, commands.Cog):
 
             added_tags.update(result)
 
-        await thread.edit(applied_tags=added_tags[:5])
+        from random import sample
+
+        added_tags_list = list(added_tags)
+        chosen_tags = added_tags_list[:5]
+        ignored_tags = added_tags_list[5:]
+        await thread.edit(applied_tags=chosen_tags)
 
         if added_tags:
             content = "Thanks for tagging your post!\nYou can change the tags at any time by using `/retag`\n\n"
-            for tag in added_tags[:5]:
+            for tag in chosen_tags:
                 content += tag_string(tag)
             if len(added_tags) > 5:
                 content += "\nThe following tags weren't added due to the 5 tags limit:\n\n"
-                for tag in added_tags[5:]:
+                for tag in ignored_tags:
                     content += tag_string(tag)
         else:
             content = "You did not select any tags for your post.\nYou can add tags at any time by using `/retag`\n"

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -150,7 +150,7 @@ class TagAskState(metaclass=ABCMeta):
     async def interact(self, message) -> set[disnake.ForumTag]:
         pass
 
-    def get_message_args(self):
+    def get_message_args(self) -> dict:
         return dict(embed=self.embed, components=self.rows)
 
     def button_click_check(self, inter: disnake.MessageInteraction) -> bool:
@@ -188,6 +188,7 @@ class TagAskState(metaclass=ABCMeta):
 
     async def ask(self, message: disnake.Message | None, inter: disnake.AppCmdInter | None):
         if message is None:
+            assert self.thread.owner is not None
             content = f"{self.thread.owner.mention} Increase your visibility by adding up to 5 tags to your post!"
 
             if inter:
@@ -835,13 +836,9 @@ class AutoHotkey(AceMixin, commands.Cog):
             try:
                 result = await question.interact(message)
             except asyncio.TimeoutError:
-                if message is not None:
-                    await message.delete()
-                return
+                break
 
             added_tags.update(result)
-
-        from random import sample
 
         added_tags_list = list(added_tags)
         chosen_tags = added_tags_list[:5]

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -46,6 +46,8 @@ DISCORD_UPLOAD_LIMIT = 8000000  # 8 MB
 
 BULLET = "•"
 
+SKIP = disnake.PartialEmoji(name="⏩")
+DONE = disnake.PartialEmoji(name="☑️")
 
 def tag_string(tag):
     return "- " + (tag.emoji.name + " " if tag.emoji else "") + tag.name + "\n"
@@ -644,8 +646,9 @@ class AutoHotkey(AceMixin, commands.Cog):
                 )
 
             row.add_button(
-                style=disnake.ButtonStyle.grey,
-                label="Skip" if single else "Skip/Done",
+                style=disnake.ButtonStyle.danger,
+                label="Skip",
+                emoji=SKIP
             )
 
             args = dict(embed=embed, components=rows)
@@ -691,15 +694,24 @@ class AutoHotkey(AceMixin, commands.Cog):
             out = []
             while True:
                 interaction = await interact()
-                if interaction is None or interaction.component.label == "Skip/Done":
+                if interaction is None or interaction.component.label == "Skip" or interaction.component.label == "Done":
                     break
                 tag = tags.get(interaction.component.label)
                 index = list(tags.keys()).index(interaction.component.label)
+                loc = (len(tags)-1)%4+1
                 if tag in out:
                     rows[int(index/4)][index%4].style = disnake.ButtonStyle.secondary
                     out.remove(tag)
+                    if not out:
+                        row[loc].style = disnake.ButtonStyle.danger
+                        row[loc].label = "Skip"
+                        row[loc].emoji = SKIP
                 else:
                     rows[int(index/4)][index%4].style = disnake.ButtonStyle.primary
+                    if not out:
+                        row[loc].style = disnake.ButtonStyle.success
+                        row[loc].label = "Done"
+                        row[loc].emoji = DONE
                     out.append(tag)
                 await message.edit(content=None, embed=embed, components=rows)
 

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -630,24 +630,25 @@ class AutoHotkey(AceMixin, commands.Cog):
 
             embed.description = question
 
-            view = []
+            rows = []
+
             for num, (label, tag) in enumerate(tags.items()):
                 if num % 4 == 0:
                     row = disnake.ui.ActionRow()
-                    view.append(row)
+                    rows.append(row)
 
                 row.add_button(
                     style=disnake.ButtonStyle.secondary,
                     label=label,
-                        emoji=tag.emoji,
-                    )
+                    emoji=tag.emoji,
+                )
 
             row.add_button(
                 style=disnake.ButtonStyle.grey,
                 label="Skip" if single else "Skip/Done",
             )
 
-            args = dict(embed=embed, components=view)
+            args = dict(embed=embed, components=rows)
 
             if message is None:
                 content = (
@@ -695,12 +696,12 @@ class AutoHotkey(AceMixin, commands.Cog):
                 tag = tags.get(interaction.component.label)
                 index = list(tags.keys()).index(interaction.component.label)
                 if tag in out:
-                    view[int(index/4)][index%4].style = disnake.ButtonStyle.secondary
+                    rows[int(index/4)][index%4].style = disnake.ButtonStyle.secondary
                     out.remove(tag)
                 else:
-                    view[int(index/4)][index%4].style = disnake.ButtonStyle.primary
+                    rows[int(index/4)][index%4].style = disnake.ButtonStyle.primary
                     out.append(tag)
-                await message.edit(content=None, embed=embed, components=view)
+                await message.edit(content=None, embed=embed, components=rows)
 
             return out
 

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -803,7 +803,10 @@ class AutoHotkey(AceMixin, commands.Cog):
                 "Which version of AHK are you using?",
                 self.bot,
                 thread,
-                {"v1.1": tags["v1"], "v2.0": tags["v2"]},
+                {
+                    "v1.1": tags["v1"],
+                    "v2.0": tags["v2"],
+                },
             ),
             MultiSelect(
                 "Which of these topics fit your question? Skip if none apply.",
@@ -815,17 +818,18 @@ class AutoHotkey(AceMixin, commands.Cog):
                     "GUI": tags["GUI"],
                     "RegEx": tags["RegEx"],
                     "WinAPI": tags["WinAPI"],
-                    "COM Objects": tags["COM Objects"],
                     "Object-Oriented": tags["Object-Oriented"],
+                    "Written by AI": tags["AI"],
                 },
             ),
             SingleSelect(
-                "Do any of the following apply to your post? Skip if none apply.",
+                "What is your AutoHotkey skill level?",
                 self.bot,
                 thread,
                 {
-                    "Written by AI": tags["ChatGPT / AI"],
-                    "Someone else wrote it": tags["Someone Else"],
+                    "Beginner": tags["Beginner"],
+                    "Intermediate": tags["Intermediate"],
+                    "Expert": tags["Expert"],
                 },
             ),
         ]
@@ -846,25 +850,17 @@ class AutoHotkey(AceMixin, commands.Cog):
         added_tags += chain.from_iterable(zip_longest(*multi_tags))
 
         chosen_tags = added_tags[:5]
-        ignored_tags = added_tags[5:]
         await thread.edit(applied_tags=chosen_tags)
 
-        def tag_string(tag):
-            return "- " + (tag.emoji.name + " " if tag.emoji else "") + tag.name + "\n"
-
         if added_tags:
-            content = "Thanks for tagging your post!\nYou can change the tags at any time by using `/retag`\n\n"
-            for tag in chosen_tags:
-                content += tag_string(tag)
-            if len(added_tags) > 5:
-                content += "\nThe following tags weren't added due to the 5 tags limit:\n\n"
-                for tag in ignored_tags:
-                    content += tag_string(tag)
+            content = "Thanks for tagging your post! You can change the tags at any time by using `/retag`\n\nAdded: {added}\n\n".format(
+                added=", ".join(f"`{tag.name}`" for tag in added_tags)
+            )
         else:
-            content = "You did not select any tags for your post.\nYou can add tags at any time by using `/retag`\n"
+            content = "You did not select any tags for your post. You can add tags at any time by using `/retag`\n\n"
 
         content += (
-            "\n**If your issue gets solved, you can mark your post as solved by sending `/solved`**"
+            "**If your issue gets solved, you can mark your post as solved by sending `/solved`**"
         )
 
         await message.edit(content=content, embed=None, components=None)

--- a/format.bat
+++ b/format.bat
@@ -1,2 +1,4 @@
+@echo off
+
 isort .
 black .


### PR DESCRIPTION
When tagging a post, you can now select multiple topic tags; an AI or someone else tag; as well as any future non-solved tags that aren't assigned to a menu. It also shows a dedicated message if no tags are selected and applies the tags on timeout.

https://github.com/user-attachments/assets/d6b85c00-067d-4923-a454-c5065cdfc554


