### PR TITLE
Added strip to tags autocomplete and migrating facts.

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -290,7 +290,7 @@ class Tags(AceMixin, commands.Cog):
         similars = await inter.bot.db.fetch(
             "SELECT * FROM tag WHERE guild_id=$1 AND (name LIKE $2 OR alias LIKE $2) ORDER BY uses DESC, viewed_at DESC LIMIT 5",
             inter.guild.id,
-            f"%{query.lower()}%",
+            f"%{query.lower().strip()}%",
         )
 
         return [build_tag_name(record, zws=True) for record in similars]

--- a/migrate.py
+++ b/migrate.py
@@ -20,7 +20,7 @@ async def main():
 
         # populate facts if empty
         if await db.fetchval("SELECT COUNT(id) FROM facts") == 0:
-            for fact in facts.split("\n"):
+            for fact in facts.strip().split("\n"):
                 await db.execute("INSERT INTO facts (content) VALUES ($1)", fact)
 
 


### PR DESCRIPTION
Fixes the issue Oz found [here](https://discord.com/channels/115993023636176902/378322175226150912/1381735794607132732) where the empty lines at the start and end of the facts string were converted to blank facts and could be sent.
Also fixes an issue with slash tags autocomplete where having a space at the start causes it to require a space (particularly annoying on mobile, which auto-adds a space when completing).