### PR TITLE
Adding more checks to the "thread owner left" feature

### DIFF
--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -1068,7 +1068,7 @@ class AutoHotkey(AceMixin, commands.Cog):
                 days=USER_LEFT_MESSAGE_DAYS_THRESHOLD
             )
             last_message = await thread.history(limit=1, after=limit_dt).flatten()
-            if last_message:
+            if not last_message:
                 continue
 
             await thread.send(

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -56,6 +56,8 @@ DISCORD_UPLOAD_LIMIT = 8000000  # 8 MB
 AHKBIN_UPLOAD_LIMIT = 1000000  # 1 MB
 AHKBIN_VALID_EXT = ("ahk", "txt", "ahk2", "py")
 
+USER_LEFT_MESSAGE_DAYS_THRESHOLD = 7
+
 BULLET = "•"
 
 SKIP = disnake.PartialEmoji(name="⏩")
@@ -1060,6 +1062,13 @@ class AutoHotkey(AceMixin, commands.Cog):
                 continue
 
             if thread.locked:
+                continue
+
+            limit_dt = datetime.now(timezone.utc) - timedelta(
+                days=USER_LEFT_MESSAGE_DAYS_THRESHOLD
+            )
+            last_message = await thread.history(limit=1, after=limit_dt).flatten()
+            if last_message:
                 continue
 
             await thread.send(

--- a/cogs/ahk/ahk.py
+++ b/cogs/ahk/ahk.py
@@ -1071,6 +1071,9 @@ class AutoHotkey(AceMixin, commands.Cog):
             if not last_message:
                 continue
 
+            if member.joined_at > last_message[0].created_at:
+                continue
+
             await thread.send(
                 embed=disnake.Embed(description="The thread owner is no longer in this server.")
             )


### PR DESCRIPTION
The goal is to:

- Prevent sending the message if the thread was last active more than 7 days ago.

- Prevent the thread owner from rejoining the server multiple times to trigger it repeatedly. (didn't happen before but it might happen)